### PR TITLE
Send viewer requests through a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ export default App;
 * _urn_: (Required) A string or array of string values for the URN(s) of the translated models you wish to load
 * _view_: (Required) An object or array of view objects to display in the viewer
 * _headless_: A boolean to display in the viewer in headless mode or not (defaults `false`)
+* _proxy_: A string that is the base url to proxy our requests through a
+  proxy. This is useful when you don't want to pass an access token to the
+client. For [more
+info...](https://forge.autodesk.com/blog/securing-your-forge-viewer-token-behind-proxy)
 * _onTokenRequest_: (Required) Callback function triggered when the viewer requests a token to access data stored on Forge. Must be a public / viewable scoped token.
 * _version_: The version of the viewer you want to load. Latest tested is 6.0.
 * _onViewerError_: Callback function triggered when the viewer encounters an error

--- a/build/index.js
+++ b/build/index.js
@@ -825,7 +825,7 @@ var ForgeViewer = function (_React$Component) {
 			console.log('Forge Viewer has finished initializing.');
 
 			if (this.props.proxy) {
-				Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'modelDerivativeV2');
+				Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'derivativeV2');
 			}
 
 			var container = this.viewerDiv.current;

--- a/build/index.js
+++ b/build/index.js
@@ -824,6 +824,10 @@ var ForgeViewer = function (_React$Component) {
 		value: function handleViewerInit() {
 			console.log('Forge Viewer has finished initializing.');
 
+			if (this.props.proxy) {
+				Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'modelDerivativeV2');
+			}
+
 			var container = this.viewerDiv.current;
 
 			// Create Viewer instance so we can load models.

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ class ForgeViewer extends React.Component {
     console.log('Forge Viewer has finished initializing.');
 
     if (this.props.proxy) {
-      Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'modelDerivativeV2')
+      Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'derivativeV2')
     }
 
     let container = this.viewerDiv.current;

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,10 @@ class ForgeViewer extends React.Component {
   handleViewerInit(){
     console.log('Forge Viewer has finished initializing.');
 
+    if (this.props.proxy) {
+      Autodesk.Viewing.endpoint.setEndpointAndApi(this.props.proxy, 'modelDerivativeV2')
+    }
+
     let container = this.viewerDiv.current;
 
     // Create Viewer instance so we can load models.


### PR DESCRIPTION
This change adds the ability to send requests the viewer makes through a proxy, instead of passing a viewer access token to the browser. 
For more info, see [this blog post](https://forge.autodesk.com/blog/securing-your-forge-viewer-token-behind-proxy)