### PR TITLE
Bump to forge viewer to v7

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -853,7 +853,7 @@ var ForgeViewer = function (_React$Component) {
 		value: function handleLoadDocumentSuccess(doc) {
 			console.log("Forge viewer has successfully loaded document:", doc);
 
-			var views = Autodesk.Viewing.Document.getSubItemsWithProperties(doc.getRootItem(), { 'type': 'geometry' }, true);
+			var views = doc.getRoot().search({ 'type': 'geometry' }, true);
 
 			//augment viewables with the doc they came from
 			views.forEach(function (viewable) {
@@ -916,14 +916,14 @@ var ForgeViewer = function (_React$Component) {
 	}, {
 		key: 'loadView',
 		value: function loadView(view) {
-			console.log('loading view:', view.viewableID);
+			console.log('loading view:', view.guid);
 			this.views[view.viewableID] = view;
 
 			var svfUrl = view.doc.getViewablePath(view);
 			var successHandler = this.handleLoadModelSuccess.bind(this);
 			var errorHandler = this.handleLoadModelError.bind(this);
 			var modelOptions = {
-				sharedPropertyDbPath: view.doc.getPropertyDbPath()
+				sharedPropertyDbPath: view.doc.getFullPath()
 			};
 
 			//load the specified model
@@ -1036,7 +1036,7 @@ var ForgeViewer = function (_React$Component) {
 		value: function render() {
 			var _this5 = this;
 
-			var version = this.props.version ? this.props.version : "6.0";
+			var version = this.props.version ? this.props.version : "7.19";
 
 			return _react2.default.createElement(
 				_reactMeasure2.default,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-forge-viewer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-forge-viewer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A component wrapper to quickly add the Forge model viewer in your React apps.",
   "main": "build/index.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -94,8 +94,8 @@ class ForgeViewer extends React.Component {
 	handleLoadDocumentSuccess(doc) {
 		console.log("Forge viewer has successfully loaded document:", doc);
 
-		let views = Autodesk.Viewing.Document.getSubItemsWithProperties(
-			doc.getRootItem(), {'type': 'geometry'}, true
+		let views = doc.getRoot().search(
+			{'type': 'geometry'}, true
 		);
 
 		//augment viewables with the doc they came from
@@ -155,14 +155,14 @@ class ForgeViewer extends React.Component {
   }
 
 	loadView(view){
-		console.log('loading view:', view.viewableID);
+		console.log('loading view:', view.guid);
 		this.views[view.viewableID] = view;
 
 		let svfUrl = view.doc.getViewablePath(view);
 		let successHandler = this.handleLoadModelSuccess.bind(this);
 		let errorHandler = this.handleLoadModelError.bind(this);
 		let modelOptions = {
-			sharedPropertyDbPath: view.doc.getPropertyDbPath()
+			sharedPropertyDbPath: view.doc.getFullPath()
 		};
 
 		//load the specified model
@@ -274,7 +274,7 @@ class ForgeViewer extends React.Component {
   }
 
   render() {
-    const version = (this.props.version) ? this.props.version: "6.0";
+    const version = (this.props.version) ? this.props.version: "7.19";
 
     return (
       <Measure bounds onResize={this.handleResize.bind(this)}>


### PR DESCRIPTION
This is a small update to support v7.19 of the forge viewer. The API has changed very slightly (documented in the [migration guide](https://forge.autodesk.com/en/docs/viewer/v7/change_history/changelog_v7/migration_guide_v6_to_v7/)).

I've also committed the `/build` directory, since that was in version control.

This change may cause clients to have to change their consumer code, since the models API has changed upstream, so it should be considered a major change.